### PR TITLE
fix(package): try better package name replace

### DIFF
--- a/pollination_dsl/package.py
+++ b/pollination_dsl/package.py
@@ -77,7 +77,7 @@ class PostDevelop(develop):
 def get_requirement_version(package_name, dependency_name):
     """Get assigned version to a dependency in package requirements."""
     req = pkg_resources.get_distribution(
-        package_name.replace('pollination.', 'pollination-')
+        package_name.replace('pollination.', 'pollination_')
     ).get_metadata('requires.txt')
     requirements = {}
     for package in pkg_resources.parse_requirements(req):


### PR DESCRIPTION
From my local test it should have worked as it was but in fails on GitHub actions: https://github.com/pollination/honeybee-radiance/pull/22/checks?check_run_id=1832715199#step:5:28

It might also be because of the fact that it tries to load the module before it being installed. We will know when the tests run next.