### PR TITLE
fix(package tag): improve dev versions handling

### DIFF
--- a/pollination_dsl/common.py
+++ b/pollination_dsl/common.py
@@ -226,7 +226,14 @@ def _get_package_version(package_data: Dict) -> str:
         return version
     # clean up the developer version
     x, y, z = xyz[:3]
-    return f'{x}.{y}.{int(z) - 1}'
+
+    try:
+        version = f'{x}.{y}.{int(z) - 1}'
+    except ValueError:
+        # development version like 0.1.dev1+gf910655.d20210207
+        version = f'{x}.{y}.0'
+
+    return version
 
 
 def _get_package_data(package_name: str) -> Dict:


### PR DESCRIPTION
For newly created packages with no previous version the semantic version looks like 0.1.dev1+yiuye03.d202343 which is different from the expected x.y.z structure. This commit add support for such cases.