### PR TITLE
feat(dag): add support for Grouped DAGs

### DIFF
--- a/pollination_dsl/dag/__init__.py
+++ b/pollination_dsl/dag/__init__.py
@@ -1,4 +1,4 @@
 from .inputs import Inputs  # expose for easy import
 from .outputs import Outputs
-from .base import DAG
+from .base import DAG, GroupedDAG
 from .task import task

--- a/pollination_dsl/dag/task.py
+++ b/pollination_dsl/dag/task.py
@@ -165,7 +165,7 @@ def _get_task_returns(func) -> NamedTuple:
     pattern = r'[\'\"]from[\'\"]\s*:\s*.*\._outputs\.(\S*)\s*[,}]'
     parent = func.__name__.replace('_', '-')
     src = inspect.getsource(func)
-    # remove the last } which happens in case of parameters input. Somene who
+    # remove the last } which happens in case of parameters input. Someone who
     # knows regex better than I do should be able to fix this by changing the pattern
     # here is an example to recreate the issue.
     #   return [


### PR DESCRIPTION
This PR introduces GroupedDAG. A GroupedDAG is similar to a standard DAG with a few key differences.

## When to use a grouped DAG instead of a DAG

GroupedDAGs are ideal for grouping short-running tasks together.  Pollination runs all the tasks under a grouped DAG in a single Pod to minimize the overhead of starting a new pod for each task.

## Limitation

* All the steps must be functions. DAGs are not allowed.
* There should be no step with loops.
* The tasks cannot have parameter outputs. Parameters can only be exposed as a DAG output.

cc: @chriswmackey and @mikkelkp - I will send a PR for the daylight factor recipe that shows how to use the new object to improve the current recipes.
