### PR TITLE
fix(grouped dag): use annotations to set the main dag

### DIFF
--- a/pollination_dsl/dag/base.py
+++ b/pollination_dsl/dag/base.py
@@ -144,5 +144,8 @@ class GroupedDAG(DAG):
                 f'Found an invalid task "{task.name}" with parameter output in ' \
                 f'GroupedDAG "{dag.name}". Only file or folder outputs are allowed in ' \
                 f'GroupedDAG.\n{task.parameter_returns}'
+            is_main = task.annotations.get('main_task', False)
+            if is_main:
+                dag.annotations['__main_task__'] = task.name
 
         return dag


### PR DESCRIPTION
This commit allows the recipe author to choose the main task in a grouped dag by setting the annotations `{'main_task': True}`