### PR TITLE
fix(packages): improve finding the packages and their versions

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,10 @@
 pytest==6.2.4
-Sphinx==3.5.4
-sphinx-bootstrap-theme==0.7.1
+Sphinx==5.3.0
+sphinx-bootstrap-theme==0.8.1
 sphinxcontrib-fulltoc==1.2.0
 sphinxcontrib-websupport==1.2.4
 twine==3.4.1
-wheel==0.36.2
-setuptools==57.0.0
+wheel==0.38.1
+setuptools==65.5.1
+jinja2==3.0.3
+markupsafe==2.0.1

--- a/pollination_dsl/common.py
+++ b/pollination_dsl/common.py
@@ -106,6 +106,12 @@ def get_requirement_version(package_name, dependency_name):
                 str(package.specifier).replace('=', '').replace('>', '').replace('<', '')
             requirements[package.project_name] = version
 
+    # catch the case of using [] in name e.g. honeybee-display[full]
+    requirements = {
+        package.split('[')[0].strip(): version
+        for package, version in requirements.items()
+    }
+
     assert dependency_name in requirements, \
         f'{dependency_name} is not a requirement for {package_name}.'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 queenbee-pollination==0.7.5
-queenbee-local>=0.3.16
-importlib-metadata>=4.8.2
+queenbee-local>=0.5.4
+importlib-metadata>=6.6.0


### PR DESCRIPTION
This commit adds the ability to find the packages when they are using `[]` in the name. An example is `honeybee-display[full]`.
