### PR TITLE
fix(package): set input to iter_modules to string

### DIFF
--- a/pollination_dsl/package.py
+++ b/pollination_dsl/package.py
@@ -61,7 +61,7 @@ def _load_plugin(module) -> Plugin:
     folder = pathlib.Path(module.__file__).parent
 
     functions = []
-    for (_, name, _) in pkgutil.iter_modules([folder]):
+    for (_, name, _) in pkgutil.iter_modules([folder.as_posix()]):
         module = importlib.import_module('.' + name, package_name)
         for attr in dir(module):
             loaded_attr = getattr(module, attr)


### PR DESCRIPTION
It is causing issues in Python 3.10

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/pkgutil.py", line 417, in get_importer
    importer = sys.path_importer_cache[path_item]
KeyError: PosixPath('/home/runner/.local/lib/python3.10/site-packages/***/honeybee_radiance_postprocess')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/runner/.local/bin/***", line 8, in <module>
    sys.exit(main())
  File "/home/runner/.local/lib/python3.10/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/runner/.local/lib/python3.10/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/runner/.local/lib/python3.10/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/runner/.local/lib/python3.10/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/runner/.local/lib/python3.10/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/runner/.local/lib/python3.10/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/runner/.local/lib/python3.10/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/runner/.local/lib/python3.10/site-packages/***_dsl/cli.py", line 187, in push_resource
    ctx.invoke(
  File "/home/runner/.local/lib/python3.10/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/runner/.local/lib/python3.10/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/runner/.local/lib/python3.10/site-packages/***_dsl/cli.py", line 172, in push_resource
    resource = load(package_name, False)
  File "/home/runner/.local/lib/python3.10/site-packages/***_dsl/package.py", line 164, in load
    package = _load_plugin(module)
  File "/home/runner/.local/lib/python3.10/site-packages/***_dsl/package.py", line 64, in _load_plugin
    for (_, name, _) in pkgutil.iter_modules([folder]):
  File "/usr/lib/python3.10/pkgutil.py", line 129, in iter_modules
    for i in importers:
  File "/usr/lib/python3.10/pkgutil.py", line 421, in get_importer
    importer = path_hook(path_item)
  File "<frozen importlib._bootstrap_external>", line 1632, in path_hook_for_FileFinder
  File "<frozen importlib._bootstrap_external>", line 1504, in __init__
  File "<frozen importlib._bootstrap_external>", line 182, in _path_isabs
AttributeError: 'PosixPath' object has no attribute 'startswith'
```